### PR TITLE
Dateクラスが見つからないエラーに対処

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,6 @@
 Bundler.require
+require 'date'
+
 Dotenv.load
 
 distance = ARGV[0] ? ARGV[0].to_i : 0


### PR DESCRIPTION
main.rb を実行したら以下のエラーが出たので、対処しました。
（ruby 2.3.0 をインストールするのが面倒だったので、ruby 2.3.6 で実行したのが原因かもしれない...）

```
$ bundle exec ruby main.rb
main.rb:5:in `<main>': uninitialized constant Date (NameError)
Did you mean?  Data
```